### PR TITLE
Fix a bug in executor env handling

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/kubernetes/KubernetesClusterSchedulerBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/kubernetes/KubernetesClusterSchedulerBackend.scala
@@ -459,10 +459,14 @@ private[spark] class KubernetesClusterSchedulerBackend(
         .withValue(cp)
         .build()
     }
-    val executorExtraJavaOptionsEnv = conf
-      .get(org.apache.spark.internal.config.EXECUTOR_JAVA_OPTIONS)
-      .map { opts =>
-        val delimitedOpts = Utils.splitCommandString(opts) ++ maybeSimpleAuthentication
+    val executorExtraJavaOptions = (
+        conf.get(org.apache.spark.internal.config.EXECUTOR_JAVA_OPTIONS)
+          ++ maybeSimpleAuthentication).mkString(" ") match {
+        case "" => None
+        case str => Some(str)
+      }
+    val executorExtraJavaOptionsEnv = executorExtraJavaOptions.map { opts =>
+        val delimitedOpts = Utils.splitCommandString(opts)
         delimitedOpts.zipWithIndex.map {
           case (opt, index) =>
             new EnvVarBuilder().withName(s"$ENV_JAVA_OPT_PREFIX$index").withValue(opt).build()

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/kubernetes/integrationtest/kerberos/KerberosPVWatcherCache.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/kubernetes/integrationtest/kerberos/KerberosPVWatcherCache.scala
@@ -72,7 +72,7 @@ private[spark] class KerberosPVWatcherCache(
           .withLabels(labels.asJava)
           .watch(new Watcher[PersistentVolume] {
             override def onClose(cause: KubernetesClientException): Unit =
-              logInfo("Ending the watch of Persistent Volumes")
+              logInfo("Ending the watch of Persistent Volumes", cause)
             override def eventReceived(action: Watcher.Action, resource: PersistentVolume): Unit = {
               val name = resource.getMetadata.getName
               action match {


### PR DESCRIPTION
Before, the code did not consider an edge case where the original extra java opts being empty.

Now executors launch correctly and the test job finishes.