### PR TITLE
[SPARK-25299] Introduce the new shuffle writer API

### DIFF
--- a/core/src/main/java/org/apache/spark/api/shuffle/ShuffleDataIO.java
+++ b/core/src/main/java/org/apache/spark/api/shuffle/ShuffleDataIO.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.api.shuffle;
+
+public interface ShuffleDataIO {
+
+    ShuffleExecutorComponents executor();
+}

--- a/core/src/main/java/org/apache/spark/api/shuffle/ShuffleDataIO.java
+++ b/core/src/main/java/org/apache/spark/api/shuffle/ShuffleDataIO.java
@@ -27,5 +27,5 @@ import org.apache.spark.annotation.Experimental;
  */
 @Experimental
 public interface ShuffleDataIO {
-    ShuffleExecutorComponents executor();
+  ShuffleExecutorComponents executor();
 }

--- a/core/src/main/java/org/apache/spark/api/shuffle/ShuffleDataIO.java
+++ b/core/src/main/java/org/apache/spark/api/shuffle/ShuffleDataIO.java
@@ -17,7 +17,15 @@
 
 package org.apache.spark.api.shuffle;
 
-public interface ShuffleDataIO {
+import org.apache.spark.annotation.Experimental;
 
+/**
+ * :: Experimental ::
+ * An interface for launching Shuffle related components
+ *
+ * @since 3.0.0
+ */
+@Experimental
+public interface ShuffleDataIO {
     ShuffleExecutorComponents executor();
 }

--- a/core/src/main/java/org/apache/spark/api/shuffle/ShuffleExecutorComponents.java
+++ b/core/src/main/java/org/apache/spark/api/shuffle/ShuffleExecutorComponents.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.api.shuffle;
+
+public interface ShuffleExecutorComponents {
+
+  void intitializeExecutor(String appId, String execId);
+
+  ShuffleWriteSupport writes();
+}

--- a/core/src/main/java/org/apache/spark/api/shuffle/ShuffleExecutorComponents.java
+++ b/core/src/main/java/org/apache/spark/api/shuffle/ShuffleExecutorComponents.java
@@ -19,7 +19,7 @@ package org.apache.spark.api.shuffle;
 
 public interface ShuffleExecutorComponents {
 
-  void intitializeExecutor(String appId, String execId);
+    void intitializeExecutor(String appId, String execId);
 
-  ShuffleWriteSupport writes();
+    ShuffleWriteSupport writes();
 }

--- a/core/src/main/java/org/apache/spark/api/shuffle/ShuffleExecutorComponents.java
+++ b/core/src/main/java/org/apache/spark/api/shuffle/ShuffleExecutorComponents.java
@@ -17,6 +17,15 @@
 
 package org.apache.spark.api.shuffle;
 
+import org.apache.spark.annotation.Experimental;
+
+/**
+ * :: Experimental ::
+ * An interface for building shuffle support for Executors
+ *
+ * @since 3.0.0
+ */
+@Experimental
 public interface ShuffleExecutorComponents {
 
     void intitializeExecutor(String appId, String execId);

--- a/core/src/main/java/org/apache/spark/api/shuffle/ShuffleExecutorComponents.java
+++ b/core/src/main/java/org/apache/spark/api/shuffle/ShuffleExecutorComponents.java
@@ -27,8 +27,7 @@ import org.apache.spark.annotation.Experimental;
  */
 @Experimental
 public interface ShuffleExecutorComponents {
+  void intitializeExecutor(String appId, String execId);
 
-    void intitializeExecutor(String appId, String execId);
-
-    ShuffleWriteSupport writes();
+  ShuffleWriteSupport writes();
 }

--- a/core/src/main/java/org/apache/spark/api/shuffle/ShuffleMapOutputWriter.java
+++ b/core/src/main/java/org/apache/spark/api/shuffle/ShuffleMapOutputWriter.java
@@ -19,6 +19,15 @@ package org.apache.spark.api.shuffle;
 
 import java.io.IOException;
 
+import org.apache.spark.annotation.Experimental;
+
+/**
+ * :: Experimental ::
+ * An interface for creating and managing shuffle partition writers
+ *
+ * @since 3.0.0
+ */
+@Experimental
 public interface ShuffleMapOutputWriter {
 
     ShufflePartitionWriter getNextPartitionWriter() throws IOException;

--- a/core/src/main/java/org/apache/spark/api/shuffle/ShuffleMapOutputWriter.java
+++ b/core/src/main/java/org/apache/spark/api/shuffle/ShuffleMapOutputWriter.java
@@ -29,10 +29,9 @@ import org.apache.spark.annotation.Experimental;
  */
 @Experimental
 public interface ShuffleMapOutputWriter {
+  ShufflePartitionWriter getNextPartitionWriter() throws IOException;
 
-    ShufflePartitionWriter getNextPartitionWriter() throws IOException;
+  void commitAllPartitions() throws IOException;
 
-    void commitAllPartitions() throws IOException;
-
-    void abort(Throwable error) throws IOException;
+  void abort(Throwable error) throws IOException;
 }

--- a/core/src/main/java/org/apache/spark/api/shuffle/ShuffleMapOutputWriter.java
+++ b/core/src/main/java/org/apache/spark/api/shuffle/ShuffleMapOutputWriter.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.api.shuffle;
+
+import java.io.IOException;
+
+public interface ShuffleMapOutputWriter {
+
+    ShufflePartitionWriter getNextPartitionWriter() throws IOException;
+
+    void commitAllPartitions() throws IOException;
+
+    void abort(Throwable error) throws IOException;
+}

--- a/core/src/main/java/org/apache/spark/api/shuffle/ShufflePartitionWriter.java
+++ b/core/src/main/java/org/apache/spark/api/shuffle/ShufflePartitionWriter.java
@@ -22,6 +22,15 @@ import java.io.OutputStream;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
 
+import org.apache.http.annotation.Experimental;
+
+/**
+ * :: Experimental ::
+ * An interface for giving streams / channels for shuffle writes
+ *
+ * @since 3.0.0
+ */
+@Experimental
 public interface ShufflePartitionWriter {
 
     OutputStream openStream() throws IOException;

--- a/core/src/main/java/org/apache/spark/api/shuffle/ShufflePartitionWriter.java
+++ b/core/src/main/java/org/apache/spark/api/shuffle/ShufflePartitionWriter.java
@@ -32,12 +32,11 @@ import org.apache.http.annotation.Experimental;
  */
 @Experimental
 public interface ShufflePartitionWriter {
+  OutputStream openStream() throws IOException;
 
-    OutputStream openStream() throws IOException;
+  long getLength();
 
-    long getLength();
-
-    default WritableByteChannel openChannel() throws IOException {
-        return Channels.newChannel(openStream());
-    }
+  default WritableByteChannel openChannel() throws IOException {
+    return Channels.newChannel(openStream());
+  }
 }

--- a/core/src/main/java/org/apache/spark/api/shuffle/ShufflePartitionWriter.java
+++ b/core/src/main/java/org/apache/spark/api/shuffle/ShufflePartitionWriter.java
@@ -19,10 +19,16 @@ package org.apache.spark.api.shuffle;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
 
 public interface ShufflePartitionWriter {
 
     OutputStream openStream() throws IOException;
 
     long getLength();
+
+    default WritableByteChannel openChannel() throws IOException {
+        return Channels.newChannel(openStream());
+    }
 }

--- a/core/src/main/java/org/apache/spark/api/shuffle/ShufflePartitionWriter.java
+++ b/core/src/main/java/org/apache/spark/api/shuffle/ShufflePartitionWriter.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.api.shuffle;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public interface ShufflePartitionWriter {
+
+    OutputStream openStream() throws IOException;
+
+    long getLength();
+}

--- a/core/src/main/java/org/apache/spark/api/shuffle/ShuffleWriteSupport.java
+++ b/core/src/main/java/org/apache/spark/api/shuffle/ShuffleWriteSupport.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.api.shuffle;
+
+import java.io.IOException;
+
+public interface ShuffleWriteSupport {
+
+   ShuffleMapOutputWriter createMapOutputWriter(
+       String appId,
+       int shuffleId,
+       int mapId,
+       int numPartitions) throws IOException;
+}

--- a/core/src/main/java/org/apache/spark/api/shuffle/ShuffleWriteSupport.java
+++ b/core/src/main/java/org/apache/spark/api/shuffle/ShuffleWriteSupport.java
@@ -29,10 +29,9 @@ import org.apache.http.annotation.Experimental;
  */
 @Experimental
 public interface ShuffleWriteSupport {
-
-   ShuffleMapOutputWriter createMapOutputWriter(
-       String appId,
-       int shuffleId,
-       int mapId,
-       int numPartitions) throws IOException;
+  ShuffleMapOutputWriter createMapOutputWriter(
+    String appId,
+    int shuffleId,
+    int mapId,
+    int numPartitions) throws IOException;
 }

--- a/core/src/main/java/org/apache/spark/api/shuffle/ShuffleWriteSupport.java
+++ b/core/src/main/java/org/apache/spark/api/shuffle/ShuffleWriteSupport.java
@@ -19,6 +19,15 @@ package org.apache.spark.api.shuffle;
 
 import java.io.IOException;
 
+import org.apache.http.annotation.Experimental;
+
+/**
+ * :: Experimental ::
+ * An interface for deploying a shuffle map output writer
+ *
+ * @since 3.0.0
+ */
+@Experimental
 public interface ShuffleWriteSupport {
 
    ShuffleMapOutputWriter createMapOutputWriter(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Introduced the new shuffle writer API and all dependent APIs: ShuffleDataIO, ShuffleExecutorComponents (executor-side shuffle plugin), writer APIs, for output streams only.

## How was this patch tested?

Compiled